### PR TITLE
Fix JPEG magic number

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -3,7 +3,7 @@ import re
 from io import BytesIO
 
 import pytest
-from PIL import ExifTags, Image, ImageFile, JpegImagePlugin
+from PIL import ExifTags, Image, ImageFile, JpegImagePlugin, UnidentifiedImageError
 
 from .helper import (
     assert_image,
@@ -718,7 +718,7 @@ class TestFileJpeg:
             return res
 
         buffer.read = read
-        with pytest.raises(OSError):
+        with pytest.raises(UnidentifiedImageError):
             Image.open(buffer)
 
         # Assert the entire file has not been read

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -706,7 +706,7 @@ class TestFileJpeg:
         with Image.open("Tests/images/icc-after-SOF.jpg") as im:
             assert im.info["icc_profile"] == b"profile"
 
-    def test_reading_not_whole_file_for_define_it_type(self):
+    def test_jpeg_magic_number(self):
         size = 4097
         buffer = BytesIO(b"\xFF" * size)  # Many xFF bytes
         buffer.max_pos = 0

--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -707,7 +707,7 @@ class TestFileJpeg:
             assert im.info["icc_profile"] == b"profile"
 
     def test_reading_not_whole_file_for_define_it_type(self):
-        size = 1024 ** 2
+        size = 4097
         buffer = BytesIO(b"\xFF" * size)  # Many xFF bytes
         buffer.max_pos = 0
         orig_read = buffer.read
@@ -721,10 +721,8 @@ class TestFileJpeg:
         with pytest.raises(OSError):
             Image.open(buffer)
 
-        # Only small part of file has been read.
-        # The upper limit of max_pos (8Kb) was chosen experimentally
-        # and increased approximately twice.
-        assert 0 < buffer.max_pos < 8 * 1024
+        # Assert the entire file has not been read
+        assert 0 < buffer.max_pos < size
 
 
 @pytest.mark.skipif(not is_win32(), reason="Windows only")


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4707

Three suggestions here. Feel free to debate them if you disagree.
- Decreasing the length of the test image data to 4097. From what I can see, this is the minimum amount needed to verify the test. If there was a reason you had it higher than that, please let us know.
- Replaced `OSError` with the more specific `PIL.UnidentifiedImageError`
- Renamed the test, just because I was confused by the original name