### PR TITLE
Updated _open check to match _accept

### DIFF
--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -338,10 +338,11 @@ class JpegImageFile(ImageFile.ImageFile):
 
     def _open(self):
 
-        s = self.fp.read(1)
+        s = self.fp.read(3)
 
-        if i8(s) != 255:
+        if s != b"\xFF\xD8\xFF":
             raise SyntaxError("not a JPEG file")
+        s = b"\xFF"
 
         # Create attributes
         self.bits = self.layers = 0


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4707

As is more clearly seen in the PNG format - https://github.com/python-pillow/Pillow/blob/1bc67c9f0fcd7727d2b011039a463d83ed6a8c69/src/PIL/PngImagePlugin.py#L621-L637 - the `SyntaxError` condition matches `_accept`. So this updates that for JPEG.